### PR TITLE
:sparkles: Support non-instance value: class and post-hook

### DIFF
--- a/example/configs/hook.toml
+++ b/example/configs/hook.toml
@@ -1,1 +1,0 @@
-[ConfigHook.AddModelParams]

--- a/example/configs/models.toml
+++ b/example/configs/models.toml
@@ -10,15 +10,10 @@ in_channel = 256
 num_classes = 80
 
 [Backbone.ResNet]
-!block = "BasicBlock"
+$block = "BasicBlock"
 in_channel = 3
 depth = 50
 layers = [1, 2, 3, 4]
-
-[BasicBlock]
-in_chan = 3
-out_chan = 4
-
 
 [SimpleHead]
 in_channel = 256

--- a/example/configs/optimizer.toml
+++ b/example/configs/optimizer.toml
@@ -1,10 +1,10 @@
 [Optimizer.AdamW]
-weight_decay=0.01
+@params = "FCN.parameters"
+weight_decay = 0.01
 
 [LRSche.CosDecay]
-# 写在config hook里
 @optimizer='AdamW'
-learning_rate=0.1
+learning_rate = 0.1
 
 [Loss.CrossEntropyLoss]
 [Loss.OHEM]

--- a/example/run.py
+++ b/example/run.py
@@ -32,11 +32,14 @@ logger.info(
 logger.info(Registry.registry_table())
 
 config.set_target_fields(config.AttrNode.target_fields + ["Backbone"])
+logger.info(config.AttrNode.target_fields)
 config.silent()
 cfg = config.load("./configs/run.toml")
 # 判断是否是相同的实例
 assert cfg.Optimizer == cfg.LRSche.CosDecay["optimizer"]
 assert cfg.Model.FCN["backbone"] == cfg.Backbone
 modules_dict, cfg_dict = config.build_all(cfg)
+
+logger.debug(modules_dict["Optimizer"].kwargs)
 logger.debug(modules_dict)
 logger.debug(cfg_dict)

--- a/example/src/model/backbone/resnet.py
+++ b/example/src/model/backbone/resnet.py
@@ -14,4 +14,7 @@ class ResNet:
     def __init__(
         self, in_channel: int, depth: int, block: BasicBlock, layers: List[int]
     ):
-        pass
+        assert block == BasicBlock
+        self.in_channel = in_channel
+        self.depth = depth
+        self.layers = layers

--- a/example/src/model/fcn.py
+++ b/example/src/model/fcn.py
@@ -1,10 +1,15 @@
 from src import MODEL
 
+IDX = 0  # for check
+
 
 @MODEL.register(is_pretrained=True)
 class FCN:
     def __init__(self, **kwargs):
-        pass
+        global IDX  # pylint: disable=global-statement
+
+        self.kwargs = kwargs
+        IDX += 1
 
     def parameters(self):
-        return "parameters of FCN"
+        return f"parameters of FCN_{IDX}"

--- a/example/src/optim/op.py
+++ b/example/src/optim/op.py
@@ -6,4 +6,5 @@ from excore.logger import logger
 @OPTIM.register()
 class AdamW:
     def __init__(self, **kwargs):
+        self.kwargs = kwargs
         logger.debug("AdamW kwargs: {}", kwargs)


### PR DESCRIPTION
This PR enhance the config rule, introduce the following features:
1. Use `$` prefix to mark the input is `class` itself instead of its instance.
    ```toml
    [Model.ResNet]
    $backbone = "BasicBlock"
    ```
    So the ResNet will get the  `<class  BasicBlock>` instead of instance of BasicBlock
2. Allow calling functions after an instance building, using rule:
    ```toml
    [Optimizer.SGD]
    @parameters = "FCN.parameters"
    ```
    So the SGD will get the  `outpout of method parameters() of FCN `， exempting to define confighook.
3. Above features can be combined. for example, you want to pass output of a  static method, you can define cinfig:
    ```toml
    [A.B]
    $arg = "C.method"
    ```
     So the `@` in the above optimizer example is necessary.
4. Support chained invocation like `FCN.net.block.parameters`

Some defects:
1. Not sure whether the `@`  and `.method` is cooperating well, more situation should be tested
2. If we want to build a module from a static method and pass its parameters to optimizer meanwhile. We cannot define config like this: `$@parameters = "Model.build.parameters"`. So the only way to solve this situation is to use config hook or define a function witch return the output of `Model.build` in such a case.