### PR TITLE
:sparkles: Support Variable Reference

### DIFF
--- a/example/configs/datasets.toml
+++ b/example/configs/datasets.toml
@@ -1,6 +1,9 @@
+size = 1024
+
 [TrainData.CityScapes]
-data_path = 'xxx'
+&train_size = "size"
 !transforms = ['RandomResize', 'RandomFlip', 'Normalize', 'Pad']
+data_path = 'xxx'
 
 
 # 如果使用默认参数不在配置文件中声明也可以, 仍然会build RandomResize
@@ -11,11 +14,13 @@ prob = 0.5
 axis = 0
 
 [Transform.Pad]
+&pad_size = "size"
 
 [Normalize]
 std = [0.5, 0.5, 0.5]
 mean = [0.5, 0.5, 0.5]
 
 [TestData.CityScapes]
-data_path = 'xxx'
 !transforms = ['Normalize']
+&test_size = "size"
+data_path = 'xxx'


### PR DESCRIPTION
This PR implments variable reference in config. Only the Variable in the top level can be refered.
```toml
A = 1

[B.C]
D = 1 

[E.F]
&G = "A"
```
In above case, only `A` can be refered