### PR TITLE
:sparkles: Support type-hints for modules

### DIFF
--- a/docs/docs/config/config_extention.mdx
+++ b/docs/docs/config/config_extention.mdx
@@ -23,3 +23,47 @@ Code navigation is provided by the an extention of excore, currently only suppor
 2. Run `excore auto-register` and `excore config-extention`.
 3. Open project by neovim, rum command `ExLoad` to manually load the cached mapping.
 
+
+## Generate Python Type Hints
+
+Run `excore generate-typehints` to generate python type hints for modules and isolated objects. You need to specify a config to get the isolated objects. For example:
+
+```
+excore generate-typehints types --class-name ModuleType --info-class-name Info --config ./configs/launch/test_optim.toml
+```
+
+It will generate a python file named `types`:
+
+```python
+from typing import Union, Any
+from excore.config.model import ModuleNode, ModuleWrapper
+
+class ModuleType:
+    Model: Union[ModuleNode, ModuleWrapper]
+    TrainData: Union[ModuleNode, ModuleWrapper]
+    TestData: Union[ModuleNode, ModuleWrapper]
+    Backbone: Union[ModuleNode, ModuleWrapper]
+    Loss: Union[ModuleNode, ModuleWrapper]
+    LRSche: Union[ModuleNode, ModuleWrapper]
+    Optimizer: Union[ModuleNode, ModuleWrapper]
+
+class Info:
+    learning_rate: Any
+    test1: Any
+    test2: Any
+    test3: Any
+    test4: Any
+```
+
+Then you can use them like:
+```python
+from .types import ModuleType, Info
+
+from excore import config
+
+cfg = config.load("xxx.toml")
+modules, run_info = config.build_all(cfg)
+
+modules: ModuleType
+run_info: Info
+```

--- a/excore/cli/_extention.py
+++ b/excore/cli/_extention.py
@@ -1,6 +1,10 @@
 import os
 import sys
 
+from typer import Argument as CArg
+from typer import Option as COp
+from typing_extensions import Annotated
+
 from .._constants import _cache_base_dir, _workspace_cfg
 from ..config._json_schema import _generate_json_schema_and_class_mapping, _generate_taplo_config
 from ..engine.logging import logger
@@ -19,3 +23,41 @@ def config_extention():
         logger.warning("You should set json_schema_fields first")
         sys.exit()
     _generate_json_schema_and_class_mapping(_workspace_cfg["json_schema_fields"])
+
+
+def _generate_typehints(entry: str, class_name: str, info_class_name: str, config: str):
+    if not _workspace_cfg["primary_fields"]:
+        logger.critical("Please initialize the workspace first.")
+        return
+    target_file = os.path.join(_workspace_cfg["src_dir"], entry + ".py")
+    logger.info(f"Generating module type hints in {target_file}.")
+    with open(target_file, "w", encoding="UTF-8") as f:
+        f.write(f"from typing import Union{', Any' if config else ''}\n")
+        f.write("from excore.config.model import ModuleNode, ModuleWrapper\n\n")
+        f.write(f"class {class_name}:\n")
+        for i in _workspace_cfg["primary_fields"]:
+            f.write(f"    {i}: Union[ModuleNode, ModuleWrapper]\n")
+    logger.info(f"Generating isolated objects type hints in {target_file}.")
+    if config:
+        from .. import config as cfg
+
+        c = cfg.load(config)
+        cfg.silent()
+        run_info = c.build_all()[1]
+        with open(target_file, "a", encoding="UTF-8") as f:
+            f.write(f"\nclass {info_class_name}:\n")
+            for key in run_info:
+                f.write(f"    {key}: Any\n")
+
+
+@app.command()
+def generate_typehints(
+    entry: Annotated[str, CArg(help="The file to generate.")] = "types",
+    class_name: Annotated[str, COp(help="The class name of type hints.")] = "TypedModules",
+    info_class_name: Annotated[str, COp(help="The class name of run_info.")] = "RunInfo",
+    config: Annotated[str, COp(help="Used generate type hints for isolated objects.")] = None,
+):
+    """
+    Generate type hints for modules and isolated objects.
+    """
+    _generate_typehints(entry, class_name, info_class_name, config)

--- a/excore/cli/_registry.py
+++ b/excore/cli/_registry.py
@@ -66,8 +66,7 @@ def _generate_registries(entry="__init__"):
     source_code = astor.to_source(source_code)
     with open(target_file, "w", encoding="UTF-8") as f:
         f.write(source_code)
-    logger.success(
-        "Generate Registry definition in {} according to `primary_fields`", target_file)
+    logger.success("Generate Registry definition in {} according to `primary_fields`", target_file)
 
 
 def _detect_assign(node, definition):
@@ -203,8 +202,7 @@ def primary_fields():
     """
     Show primary_fields.
     """
-    table = _create_table("FIELDS", _parse_registries(
-        _workspace_cfg["registries"])[0])
+    table = _create_table("FIELDS", _parse_registries(_workspace_cfg["registries"])[0])
     logger.info(table)
 
 
@@ -213,8 +211,7 @@ def registries():
     """
     Show registries.
     """
-    table = _create_table("Registry", [_format(i)
-                          for i in _workspace_cfg["registries"]])
+    table = _create_table("Registry", [_format(i) for i in _workspace_cfg["registries"]])
     logger.info(table)
 
 

--- a/tests/test_z_cli.py
+++ b/tests/test_z_cli.py
@@ -25,5 +25,14 @@ def test_primary():
     excute("excore primary-fields")
 
 
+def test_typehints():
+    excute(
+        "excore generate-typehints temp_typing --class-name "
+        "TypedWrapper --info-class-name Info --config ./configs/launch/test_optim.toml"
+    )
+    assert os.path.exists("./source_code/temp_typing.py")
+    from source_code.temp_typing import Info, TypedWrapper  # noqa: F401
+
+
 def test_clear_cache():
     excute("excore clear-cache")


### PR DESCRIPTION
This PR implements type hinting for built modules, usage:
```sh
excore generate-typehints types TypedModule
```
```python
from excore import config
from types import TypedModule
cfg = config.load("xxx.toml")
modules, run_info = config.build_all(cfg)
modules: TypedModule
model = modules.Model
....
```