### PR TITLE
:construction_worker::bug: Add ci of example and fix bugs

### DIFF
--- a/.github/workflows/example.yaml
+++ b/.github/workflows/example.yaml
@@ -1,0 +1,36 @@
+
+name: example
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: 1.6.1
+
+      - name: Install Dependencies
+        run: poetry install --with dev
+
+      - name: Test with pytest
+        run: |
+          cd ./example
+          poetry run python init.py
+          python run.py

--- a/.github/workflows/example.yaml
+++ b/.github/workflows/example.yaml
@@ -29,8 +29,8 @@ jobs:
       - name: Install Dependencies
         run: poetry install --with dev
 
-      - name: Test with pytest
+      - name: Test example
         run: |
           cd ./example
           poetry run python init.py
-          python run.py
+          poetry run python run.py

--- a/example/README.md
+++ b/example/README.md
@@ -1,4 +1,6 @@
-1. `excore init`
-2. `excore auto-register`
-3. `excore config-extention`
-4. python run.py
+1. Run `excore init`
+2. Edit `registries` in `.excore.toml` to `registries = [ "*Model: Model, Backbone", "*Data: TrainData, TestData", "Hook", "*Loss", "*LRSche", "*Optimizer", "Transform", "module"]`
+3. Run `excore update`, you can see some config items are upadted in `.excore.toml`
+4. Run `excore auto-register`
+5. Run `excore config-extention`
+6. Run `python run.py`

--- a/example/README.md
+++ b/example/README.md
@@ -1,6 +1,15 @@
+## Mannuly setup
+
 1. Run `excore init`
 2. Edit `registries` in `.excore.toml` to `registries = [ "*Model: Model, Backbone", "*Data: TrainData, TestData", "Hook", "*Loss", "*LRSche", "*Optimizer", "Transform", "module"]`
 3. Run `excore update`, you can see some config items are upadted in `.excore.toml`
 4. Run `excore auto-register`
 5. Run `excore config-extention`
 6. Run `python run.py`
+
+## Automaticly setup
+```bash
+python init.py
+```
+
+Then you can run `python run.py`

--- a/example/configs/datasets.toml
+++ b/example/configs/datasets.toml
@@ -1,7 +1,7 @@
 size = 1024
 
 [TrainData.CityScapes]
-&train_size = "size"
+&img_size = "size"
 !transforms = ['RandomResize', 'RandomFlip', 'Normalize', 'Pad']
 data_path = 'xxx'
 
@@ -22,5 +22,5 @@ mean = [0.5, 0.5, 0.5]
 
 [TestData.CityScapes]
 !transforms = ['Normalize']
-&test_size = "size"
+&img_size = "size"
 data_path = 'xxx'

--- a/example/init.py
+++ b/example/init.py
@@ -1,0 +1,46 @@
+import subprocess
+
+import toml
+
+predefined_inputs = {
+    "name": "example_test",
+    "src": "src",
+}
+
+
+def excute(command: str, inputs=None):
+    if inputs:
+        result = subprocess.run(
+            command.split(" "), input="\n".join(inputs), text=True, capture_output=True
+        )
+    else:
+        result = subprocess.run(
+            command.split(" "),
+            capture_output=True,
+        )
+    assert result.returncode == 0, result.stderr
+
+
+def init():
+    excute("excore init --force", predefined_inputs.values())
+    cfg = toml.load("./.excore.toml")
+    cfg["registries"] = [
+        "*Model: Model, Backbone",
+        "*Data: TrainData, TestData",
+        "*Backbone",
+        "Head",
+        "Hook",
+        "*Loss",
+        "*LRSche",
+        "*Optimizer",
+        "Transform",
+        "module",
+    ]
+    with open("./.excore.toml", "w", encoding="UTF-8") as f:
+        toml.dump(cfg, f)
+    excute("excore update")
+    excute("excore auto-register")
+
+
+if __name__ == "__main__":
+    init()

--- a/example/src/dataset/dataset.py
+++ b/example/src/dataset/dataset.py
@@ -5,5 +5,5 @@ from src import DATA
 
 @DATA.register()
 class CityScapes:
-    def __init__(self, data_path: str, train_size: List[int]):
+    def __init__(self, data_path: str, img_size: List[int], transforms):
         pass

--- a/example/src/model/backbone/resnet.py
+++ b/example/src/model/backbone/resnet.py
@@ -5,7 +5,7 @@ from src import MODEL
 
 @MODEL.register(is_backbone=False)
 class BasicBlock:
-    def __init__(self, in_chan, out_chan):
+    def __init__(self, in_chan=0, out_chan=0):
         pass
 
 

--- a/excore/_exceptions.py
+++ b/excore/_exceptions.py
@@ -34,6 +34,10 @@ class CoreConfigParseError(BaseException):
     pass
 
 
+class ImplicitModuleParseError(BaseException):
+    pass
+
+
 class ModuleBuildError(BaseException):
     pass
 

--- a/excore/cli/_registry.py
+++ b/excore/cli/_registry.py
@@ -178,8 +178,12 @@ def _auto_register(target_dir, module_name):
             _auto_register(full_path, module_name + "." + file_name)
         elif file_name.endswith(".py") and file_name != "__init__.py":
             import_name = module_name + "." + file_name[:-3]
-            logger.info("Register file {}", import_name)
-            importlib.import_module(import_name)
+            try:
+                importlib.import_module(import_name)
+            except Exception:
+                logger.success("Fail to register file {}", import_name)
+                continue
+            logger.success("Register file {}", import_name)
 
 
 @app.command()

--- a/excore/config/lazy_config.py
+++ b/excore/config/lazy_config.py
@@ -42,11 +42,11 @@ class LazyConfig:
             _, base = Registry.find(list(hook_cfgs.keys())[0])
             reg = Registry.get_registry(base)
             for name, params in hook_cfgs.items():
-                hook = ConfigHookNode.from_str(reg[name], **params)()
+                hook = ConfigHookNode.from_str(reg[name], params)()
                 if hook:
                     hooks.append(hook)
                 else:
-                    self._config[name] = InterNode.from_str(reg[name], **params)
+                    self._config[name] = InterNode.from_str(reg[name], params)
         self.hooks = ConfigHookManager(hooks)
 
     def __getattr__(self, __name: str) -> Any:

--- a/excore/config/parse.py
+++ b/excore/config/parse.py
@@ -1,6 +1,6 @@
 from typing import Dict, List, Set, Type
 
-from .._exceptions import CoreConfigParseError
+from .._exceptions import CoreConfigParseError, ImplicitModuleParseError
 from ..engine import Registry, logger
 from ..utils.misc import _create_table
 from .model import (
@@ -31,7 +31,7 @@ def _check_implicit_module(module: ModuleNode) -> None:
         ):
             empty.append(param.name)
     if empty:
-        raise CoreConfigParseError(
+        raise ImplicitModuleParseError(
             f"Parse class `{cls.__name__}` to `Implicit`, "
             f"but find parameters: {empty} without default value."
         )

--- a/tests/configs/launch/test_implicit.toml
+++ b/tests/configs/launch/test_implicit.toml
@@ -1,0 +1,3 @@
+[Model.FCN]
+!classifier = "FCNHead"
+backbone = ""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,12 @@ import torch
 from torchvision.models import VGG, ResNet
 
 from excore import config
-from excore._exceptions import CoreConfigParseError, CoreConfigSupportError, ModuleBuildError
+from excore._exceptions import (
+    CoreConfigParseError,
+    CoreConfigSupportError,
+    ImplicitModuleParseError,
+    ModuleBuildError,
+)
 from excore.config.model import ModuleNode
 
 
@@ -97,7 +102,7 @@ class TestConfig:
             self._load("./configs/launch/test_conflict_name.toml", False)
 
     def test_other_field(self):
-        with pytest.raises(CoreConfigParseError):
+        with pytest.raises(ImplicitModuleParseError):
             self._load("./configs/launch/test_other_field.toml", False)
 
     def test_dump(self):
@@ -140,3 +145,7 @@ class TestConfig:
         assert id(modules.Model.FCN.backbone) == id(modules.Model.DeepLabV3.backbone)
         assert id(modules.Backbone) == id(modules.Model.FCN.backbone)
         assert id(modules.Model.FCN.classifier) != id(modules.Model.DeepLabV3.classifier)
+
+    def test_implicit_module_parse(self):
+        with pytest.raises(ImplicitModuleParseError):
+            self._load("./configs/launch/test_implicit.toml", False)


### PR DESCRIPTION
1. Add ci to example
2. Update README of example
3. Make auto-register more robust
4. Add `ImplicitModuleParseError`
5. Fix config hook building error